### PR TITLE
fix ci

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ select = [
 ]
 ignore = ["F401", "E722"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "testing/**" = ["S", "B011", "B904"]
 "src/pdbpp.py" = [
     "B019" # lru cache can lead to memory leaks. TODO: stop silencing the error and fix it

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -195,10 +195,10 @@ class ArgWithCount(str):
         return obj
 
     def __repr__(self):
-        return "<{} cmd_count={!r} value={}>".format(
-            self.__class__.__name__,
-            self.cmd_count,
-            super().__repr__(),
+        return (
+            f"<{self.__class__.__name__}"
+            f" cmd_count={self.cmd_count!r}"
+            f" value={super().__repr__()}>"
         )
 
 

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -2476,7 +2476,7 @@ def test_sticky_dunder_exception_with_highlight():
 <COLORCURLINE>  ->         raises().*
 <COLORLNUM>InnerTestException: <COLORRESET>
 # c
-    """.format(
+    """.format( # noqa: UP032
         filename=RE_THIS_FILE_CANONICAL,
     ))
 


### PR DESCRIPTION
- update pyproject for new ruff configuration format
- silence ruff warning
- replace .format with f-string