### PR TITLE
remove deprecated references to distutils.spawn

### DIFF
--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -1916,13 +1916,10 @@ except for when using the function decorator.
             try:
                 editor = os.environ["EDITOR"]
             except KeyError:
-                try:
-                    from shutil import which
-                except ImportError:
-                    from distutils.spawn import find_executable as which
-                editor = which("vim")
-                if editor is None:
-                    editor = which("vi")
+                from shutil import which
+
+                editor = which("vim") or which("vi")
+
             if not editor:
                 raise RuntimeError(
                     "Could not detect editor. Configure it or set $EDITOR."


### PR DESCRIPTION
shutil.which has been available since 3.3
