### PR TITLE
nox: use uv backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,13 +56,12 @@ jobs:
           path: ${{ github.workspace }}/.nox/tests-${{ matrix.python }}
           key: "nox|${{ matrix.os }}|tests-${{ matrix.python }}|${{ env.PY_CACHE_KEY }}|${{ hashFiles('noxfile.py', 'setup.py', 'pyproject.toml') }}"
 
-      - name: Update tools and print info
+      - name: Install tools and print info
         run: |
-          pip install -U pip setuptools virtualenv
-          pip list
-
-      - name: Install nox
-        run: pip install nox==2023.4.22
+          pip install -U pip uv nox
+          pip --version
+          uv --version
+          nox --version
 
       - name: Test
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,15 +46,12 @@ jobs:
           path: ${{ github.workspace }}/.nox/lint
           key: "nox-lint|${{ matrix.os }}|${{ env.PY_CACHE_KEY }}|${{ hashFiles('noxfile.py', 'setup.py', 'pyproject.toml') }}"
 
-      - name: Update pip/setuptools
+      - name: Install tools
         run: |
-          pip install -U pip setuptools
-
-      - name: Install nox
-        run: pip install nox==2023.4.22
-
-      - name: Version information
-        run: pip list
+          pip install -U pip uv nox
+          pip --version
+          uv --version
+          nox --version
 
       - name: Lint
         run: nox -v -s lint

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,6 +5,8 @@ import nox
 
 nox.options.reuse_existing_virtualenvs = True
 nox.options.sessions = "lint", "tests"
+nox.options.default_venv_backend = "uv"
+locations = "src", "testing"
 
 
 @nox.session(


### PR DESCRIPTION
It's faster.

Note that this might cause some issues when not using `readline`: uv builds by default use `libedit`.
