### PR TITLE
pdbrc.py example: use pdbpp.DefaultConfig as base

### DIFF
--- a/pdbrc.py
+++ b/pdbrc.py
@@ -3,12 +3,13 @@ This is an example configuration file for pdb++.
 
 Put it into ~/.pdbrc.py to use it.
 """
-import pdb
+
+import pdbpp
 
 from pygments.styles import get_style_by_name
 
 
-class Config(pdb.DefaultConfig):
+class Config(pdbpp.DefaultConfig):
     # prompt = "(Pdb++) "
     sticky_by_default = True  # shows full code context at every step
 


### PR DESCRIPTION
avoids Exceptions when `PDBPP_HIJACK_PDB=0` is set (`AttributeError`)

