### PR TITLE
Fixing loading of original pdb in embedded Python

### DIFF
--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -63,9 +63,14 @@ def import_from_stdlib(name):
 
     stdlibdir, _ = os.path.split(code.__file__)
     pyfile = os.path.join(stdlibdir, f"{name}.py")
-    with open(pyfile) as f:
-        src = f.read()
-    co_module = compile(src, pyfile, "exec", dont_inherit=True)
+    if os.path.isdir(stdlibdir):
+        with open(pyfile) as f:
+            src = f.read()
+        co_module = compile(src, pyfile, "exec", dont_inherit=True)
+    if os.path.isfile(stdlibdir):
+        import zipimport
+        zi = zipimport.zipimporter(stdlibdir)
+        co_module = zi.get_code(name)        
     exec(co_module, result.__dict__)
 
     return result

--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -67,6 +67,8 @@ def import_from_stdlib(name):
         with open(pyfile) as f:
             src = f.read()
         co_module = compile(src, pyfile, "exec", dont_inherit=True)
+    # If you're using the Windows embeddable package, then stdlibdir is not a
+    # directory but a file named python3xx.zip.
     if os.path.isfile(stdlibdir):
         import zipimport
         zi = zipimport.zipimporter(stdlibdir)


### PR DESCRIPTION
Thank you for continuing to support the project.
If you are using embedded Python, then 
`code.__file__ == 'PATH_TO_EMBEDDED\\python312.zip\\code.pyc`
And `stdlibdir` is a zip archive with .pyc files, so we need to read the compiled module code from it using `zipimport`.