### PR TITLE
update release workflow, fix nox build session

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Publish package to PyPI
 
 on:
+  push:
+    branches:
+      - "master"
   release:
     types:
       - published
@@ -13,15 +16,21 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install requirements
         run: |
-          pip install twine nox[uv]==2025.2.9
+          pip install twine nox[uv]==2025.5.1
       - name: Build
         run: nox -s build
+      - name:
+        if: github.event_name != 'release'
+        run: |
+          echo "::warning::Not a release, not uploading to PyPi"
+          ls -l dist/*
       - name: Publish to PyPI
+        if: github.event_name == 'release'
         env:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -46,7 +46,7 @@ def lint(session: nox.Session) -> None:
 @nox.session
 def build(session: nox.Session) -> None:
     session.install("build", "setuptools", "twine")
-    session.run("python", "-m", "build")
+    session.run("python", "-m", "build", "--installer=uv")
     dists = glob.glob("dist/*")
     session.run("twine", "check", *dists, silent=True)
 


### PR DESCRIPTION
- use [`astral-sh/setup-uv`](https://github.com/astral-sh/setup-uv) action instead of `actions/setup-python`
- add `--installer=uv` to nox's `build` session
- update workflow to do a dry-run on every push
