### PR TITLE
standardize release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
-name: Publish package to PyPI
+name: release
+run-name: ${{ (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags'))) && 'Publish to PyPI' || '(dry run) Publish to PyPI' }}
 
 on:
   push:
@@ -10,7 +11,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,19 +20,40 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.13"
+      - name: check if release
+        id: is-release
+        run: |
+          is_release=${{(github.event_name == 'release') || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags'))}}
+          echo "value=${is_release}" | tee -a "${GITHUB_OUTPUT}"
       - name: Install requirements
         run: |
           uv pip install -U twine nox==2025.5.1
       - name: Build
         run: nox -s build
+
       - name:
-        if: github.event_name != 'release'
+        if: ${{ steps.is-release.outputs.value == 'false' }}
         run: |
           echo "::warning::Not a release, not uploading to PyPi"
           ls -l dist/*
+
       - name: Publish to PyPI
-        if: github.event_name == 'release'
+        if: ${{ steps.is-release.outputs.value == 'true' }}
         env:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: twine upload dist/*
+        run: |
+          twine upload dist/*
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
+        if: ${{steps.is-release.outputs.value == 'true' }}
+        with:
+          name: "wheel"
+          path: dist/*whl
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        if: ${{steps.is-release.outputs.value == 'true' }}
+        with:
+          name: "sdist"
+          path: dist/*.tar.gz


### PR DESCRIPTION

use the same release workflow across `pdbpp`, `pyrepl` and `fancycompleter`:

https://github.com/bretello/pyrepl/commit/4a658b5a2b7ce869fdee0caabf8b7c306fbe6ed5
https://github.com/bretello/fancycompleter/commit/470d51d136bd2a33c84681375bde17c65816826d
