### PR TITLE
PdbMeta: fix instantiation of Pdb subclasses

### DIFF
--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -274,7 +274,7 @@ class PdbMeta(type):
             return global_pdb
 
         obj = cls.__new__(cls)
-        if called_for_set_trace:
+        if cls is Pdb and called_for_set_trace:
             kwargs.setdefault("start_filename", called_for_set_trace.f_code.co_filename)
             kwargs.setdefault("start_lineno", called_for_set_trace.f_lineno)
 


### PR DESCRIPTION
`PdbMeta` meta is the metaclass responsible for reusing existing Pdb instances in order to persist state across different `breakpoint()`/`set_trace` invocations

When `Pdb` is subclasses, this causes Pdbpp-specific parameters to be passed to the class' init, causing instantiation to fail.

fixes #60
