### PR TITLE
fix: `disable.set_trace` added `**kwargs`

### DIFF
--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -2221,8 +2221,7 @@ def disable():
         local.GLOBAL_PDB.disabled = True
 
 
-disable.set_trace = lambda frame=None, Pdb=Pdb: None
-
+disable.set_trace = lambda frame=None, Pdb=Pdb, **kwargs: None
 
 def set_tracex():
     print("PDB!")


### PR DESCRIPTION
Fixes #59. From my understanding, at least. Untested! But quite a minor change. I added `**kwargs` without removing the keyword arguments `frame` and `Pdb` like in #59 to cause minimum alteration.