### PR TITLE
gha: skip nox build on pypy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,4 +78,5 @@ jobs:
           fail_ci_if_error: true
 
       - name: Build package
+        if: ${{ !contains(matrix.python, 'pypy') }}
         run: nox -s build


### PR DESCRIPTION
Installing `twine` on pypy requires building some of the deps (`nh3`, `cryptography`).

`nh3`, which is dependency of `readme_renderer>=42.0`, used as a replacement for `bleach`, fails because of rust dependencies (`pyo3-ffi` fails to build).
