### PR TITLE
fix python -m pdb on 3.14.2+

### DIFF
--- a/src/pdbpp.py
+++ b/src/pdbpp.py
@@ -2154,6 +2154,8 @@ if sys.version_info >= (3, 11):
     to_rebind += ["_ModuleTarget", "_ScriptTarget"]
 if sys.version_info >= (3, 13):
     to_rebind += ["itertools", "_colorize"]
+if sys.version_info >= (3, 14, 2):
+    to_rebind += ["parse_args"]
 for name in to_rebind:
     func = getattr(pdb, name)
     globals()[name] = rebind_globals(func, globals())


### PR DESCRIPTION

`test_python_m_pdb_uses_pdbpp_and_env` is now failing on 3.14.2 because of the newly defined `parse_args` function is not found

CI logs: https://github.com/bretello/pdbpp/actions/runs/20256854487/job/58160688047#step:7:101

upstream change: https://github.com/python/cpython/pull/140933
